### PR TITLE
Add Flask text adventure server using OpenAI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# AI Chat GPT Game
+
+This project contains a small Flask application that uses the OpenAI API to
+host a text-based adventure game. The server generates the story and multiple
+choice options via the API.
+
+## Setup
+
+1. Create and activate a virtual environment.
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Set the OpenAI API key:
+
+   ```bash
+   export OPENAI_API_KEY="your_api_key_here"
+   ```
+
+4. (Optional) Set a secret key for Flask sessions:
+
+   ```bash
+   export FLASK_SECRET_KEY="change_me"
+   ```
+
+## Running the server
+
+Start the development server:
+
+```bash
+python app.py
+```
+
+Open a browser to `http://127.0.0.1:5000` and follow the prompts to play.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,77 @@
+import json
+import os
+
+from flask import Flask, render_template, request, session
+import openai
+
+app = Flask(__name__)
+app.secret_key = os.getenv("FLASK_SECRET_KEY", "dev")
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+
+
+def call_openai(messages):
+    """Call the OpenAI API and return story text and options.
+
+    The assistant is instructed to reply with JSON containing the keys
+    ``story`` and ``options``. ``options`` should be a list of strings.
+    """
+    if not openai.api_key:
+        raise RuntimeError("OPENAI_API_KEY is required to generate game content.")
+
+    response = openai.ChatCompletion.create(
+        model=MODEL,
+        messages=messages,
+        temperature=0.7,
+    )
+    content = response["choices"][0]["message"]["content"]
+
+    try:
+        data = json.loads(content)
+        story = data.get("story", "")
+        options = data.get("options", [])
+    except json.JSONDecodeError:
+        # If the model's response isn't valid JSON, return it as-is with no options.
+        story = content
+        options = []
+
+    messages.append({"role": "assistant", "content": content})
+    return story, options, messages
+
+
+@app.route("/")
+def index():
+    """Start a new game."""
+    # Initialize conversation with system prompt
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are a text-based adventure game engine. "
+                "After each player choice, describe the next part of the story "
+                "and provide three numbered options for the player to choose from. "
+                "Respond in JSON with keys 'story' and 'options'."
+            ),
+        }
+    ]
+
+    story, options, messages = call_openai(messages)
+    session["messages"] = messages
+    return render_template("game.html", story=story, options=options)
+
+
+@app.route("/play", methods=["POST"])
+def play():
+    """Continue the game with the player's chosen option."""
+    choice = request.form.get("option")
+    messages = session.get("messages", [])
+    messages.append({"role": "user", "content": choice})
+
+    story, options, messages = call_openai(messages)
+    session["messages"] = messages
+    return render_template("game.html", story=story, options=options)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+openai

--- a/templates/game.html
+++ b/templates/game.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>AI Text Adventure</title>
+  </head>
+  <body>
+    <h1>AI Text Adventure</h1>
+    <p>{{ story }}</p>
+    {% if options %}
+    <form method="post" action="{{ url_for('play') }}">
+      {% for opt in options %}
+      <div>
+        <button type="submit" name="option" value="{{ opt }}">{{ opt }}</button>
+      </div>
+      {% endfor %}
+    </form>
+    {% else %}
+    <p><em>No more options available.</em></p>
+    <a href="{{ url_for('index') }}">Start over</a>
+    {% endif %}
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Create Flask app generating text adventure story and options via OpenAI API.
- Add HTML template for interactive multiple-choice interface.
- Document setup, dependencies, and running instructions.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1318167848322abe09d3b1301d905